### PR TITLE
refactor-workflows-use-only-current-repo

### DIFF
--- a/.github/workflows/build_and_publish_installer.yml
+++ b/.github/workflows/build_and_publish_installer.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  UPDATE_URL: https://github.com/${{ github.repository }}/releases/latest/download/ct-cli.zip
+  RELEASES_URL: https://api.github.com/repos/${{ github.repository }}/releases
   PUBLISHER_NAME: ${{ vars.PUBLISHER_NAME }}
   PUBLISHER_URL: ${{ vars.PUBLISHER_URL }}
   PUBLISHER_EMAIL: ${{ vars.PUBLISHER_EMAIL }}
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
         run: |
           $template = Get-Content installer/installer.template.ps1 -Raw -Encoding UTF8
-          $script = $template -replace '__UPDATE_URL__', $env:UPDATE_URL `
+          $script = $template -replace '__RELEASES_URL__', $env:RELEASES_URL `
                               -replace '__RELEASE_TAG__', $env:RELEASE_TAG `
                               -replace '__CT_SUBDOMAIN__', $env:CT_SUBDOMAIN
           $script | Set-Content installer/installer.ps1 -Encoding UTF8NoBOM

--- a/installer/installer.template.ps1
+++ b/installer/installer.template.ps1
@@ -40,8 +40,7 @@ function Get-CLICode {
         }
         Invoke-WebRequest -Uri $cliAsset.browser_download_url -OutFile $ZipFile -UseBasicParsing
     } catch {
-        [Microsoft.VisualBasic.Interaction]::MsgBox("Fehler beim Herunterladen der ZIP-Datei: $_", "OKOnly,Critical", "Download-Fehler")
-        exit 1
+        throw "ZIP-Datei konnte nicht heruntergeladen werden: $_"
     }
     Expand-Archive -Path $ZipFile -DestinationPath $InstallPath -Force
     Remove-Item $ZipFile -Force

--- a/installer/installer.template.ps1
+++ b/installer/installer.template.ps1
@@ -1,7 +1,7 @@
 Add-Type -AssemblyName Microsoft.VisualBasic
 
 $releaseVersion = "__RELEASE_TAG__"
-$ZipUrl = "__UPDATE_URL__"
+$ReleasesUrl = "__RELEASES_URL__"
 $ZipFile = "$env:TEMP\ct.zip"
 $InstallPath = "$env:USERPROFILE\.ct"
 $MainPS1File = Join-Path $InstallPath "ct.ps1"
@@ -23,7 +23,22 @@ function Check-Compatibility {
 
 function Get-CLICode {
     try {
-        Invoke-WebRequest -Uri $ZipUrl -OutFile $ZipFile -UseBasicParsing
+        $response = Invoke-WebRequest -Uri $ReleasesUrl
+        $releases = $response.Content | ConvertFrom-Json
+        if ($releases.Count -eq 0) {
+            throw "Kein Release gefunden."
+        }
+        $latestRelease = $releases | Sort-Object { [datetime]$_.published_at } -Descending | Select-Object -First 1
+        $assetsResponse = Invoke-WebRequest -Uri $latestRelease.assets_url
+        $assets = $assetsResponse.Content | ConvertFrom-Json
+        if ($assets.Count -eq 0) {
+            throw "Keine Assets für Release $($latestRelease.tag_name) gefunden."
+        }
+        $cliAsset = $assets | Where-Object { $_.name -eq "ct-cli.zip" }
+        if (-not $cliAsset) {
+            throw "Die relevanten Dateien wurden nicht in den Release Assets gefunden."
+        }
+        Invoke-WebRequest -Uri $cliAsset.browser_download_url -OutFile $ZipFile -UseBasicParsing
     } catch {
         [Microsoft.VisualBasic.Interaction]::MsgBox("Fehler beim Herunterladen der ZIP-Datei: $_", "OKOnly,Critical", "Download-Fehler")
         exit 1
@@ -39,7 +54,7 @@ function Add-InitFlag {
 
 function Write-EnvFile {
     $content = @"
-UPDATE_URL=$ZipUrl
+RELEASES_URL=$ReleasesUrl
 VERSION=$releaseVersion
 CT_SUBDOMAIN=__CT_SUBDOMAIN__
 "@


### PR DESCRIPTION
Use only one repository after all > adjust workflows to post cli installer or code as release assets