### PR TITLE
refactor-command-structure

### DIFF
--- a/cli_code/Classes/ChurchTools.ps1
+++ b/cli_code/Classes/ChurchTools.ps1
@@ -47,7 +47,7 @@ class ChurchTools {
             $this.User = Get-Content $this.CachePath -Raw | ConvertFrom-Json
         } else {
             try {
-                Write-Host "Lade Nutzerdaten..."
+                Out-Message "Lade Nutzerdaten..."
                 $userData = $this.CallApi("GET", "whoami", $null, $null)
                 $groups = $this.CallApi("GET", "persons/$($userData.id)/groups", $null, $null)
                 $this.User = [PSCustomObject]@{

--- a/cli_code/Commands/version.ps1
+++ b/cli_code/Commands/version.ps1
@@ -1,5 +1,5 @@
 try {
-    Write-Host $VERSION
+    Out-Message $VERSION
 } catch {
     $log.Write("Error in version.ps1 $($_.Exception.Message)")
 }

--- a/cli_code/Commands/wer-bin-ich.ps1
+++ b/cli_code/Commands/wer-bin-ich.ps1
@@ -1,8 +1,8 @@
 $ct = [ChurchTools]::new($CT_API_URL, $CT_API_TOKEN)
 
 try {
-    Write-Host "Angemeldet als $($ct.User.firstName) $($ct.User.lastName)"
-    Write-Host "Email: $($ct.User.email)"
+    Out-Message "Angemeldet als $($ct.User.firstName) $($ct.User.lastName)"
+    Out-Message "Email: $($ct.User.email)"
 } catch {
     $log.Write("Error in hilfe.ps1 $($_.Exception.Message)")
 }

--- a/cli_code/Modules/Commands.psm1
+++ b/cli_code/Modules/Commands.psm1
@@ -41,7 +41,6 @@ function Get-CommandPath {
         $expectedPathParts = Join-Path $expectedPathParts ($SubCommands -join "\")
     }
     $expectedPath = $expectedPathParts + ".ps1"
-    Write-Host $expectedPath
     if (Test-Path $expectedPath) {
         return $expectedPath
     } 

--- a/cli_code/Modules/Commands.psm1
+++ b/cli_code/Modules/Commands.psm1
@@ -1,0 +1,49 @@
+function Get-ParsedArgs {
+    param (
+        [string]$ArgsStr
+    )
+    
+    $subcommands = @()
+    $args = @{}
+    $flags = @{}
+
+    $tokens = $ArgsStr -split '\s+'
+    
+    foreach ($token in $tokens) {
+        if ($token -match '^--.+$') {
+            $tokenKey = $token -replace "^--", ""
+            $flags[$tokenKey] = $true
+        }
+        elseif ($token -match '^[a-zA-Z0-9-]+=[a-zA-Z0-9-]+$') {
+            $key, $value = $token -split '='
+            $args[$key] = $value
+        }
+        else {
+            $subcommands += $token
+        }
+    }
+
+    return @{
+        Subcommands = $subcommands
+        Arguments   = $args
+        Flags       = $flags
+    }
+}
+
+function Get-CommandPath {
+    param(
+        [string]$CommandsDir,
+        [string]$Command,
+        [string[]]$SubCommands
+    )
+    $expectedPathParts = Join-Path $CommandsDir $Command
+    if ($SubCommands.Count -gt 0) {
+        $expectedPathParts = Join-Path $expectedPathParts ($SubCommands -join "\")
+    }
+    $expectedPath = $expectedPathParts + ".ps1"
+    Write-Host $expectedPath
+    if (Test-Path $expectedPath) {
+        return $expectedPath
+    } 
+    return ""
+}

--- a/cli_code/Modules/DotEnv.psm1
+++ b/cli_code/Modules/DotEnv.psm1
@@ -1,15 +1,11 @@
-function Get-DotEnv {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [string]$Path
-    )
+$EnvPath = Join-Path $PWD ".env"
 
-    if (-Not (Test-Path $Path)) {
-        Throw "File not found: $Path"
+function Get-DotEnv {
+    if (-Not (Test-Path $EnvPath)) {
+        Throw "File not found: $EnvPath"
     }
 
-    Get-Content $Path | ForEach-Object {
+    Get-Content $EnvPath | ForEach-Object {
         if ($_ -match '^\s*([^#][\w\.]+)\s*=\s*(.*)$') {
             $name, $value = $matches[1], $matches[2]
             Set-Variable -Name $name -Value $value -Scope Global
@@ -21,7 +17,6 @@ Export-ModuleMember -Function Get-DotEnv
 
 function Update-DotEnv {
     param(
-        [string]$EnvPath,
         [hashtable]$KeyValuePairs
     )
 

--- a/cli_code/Modules/Help.psm1
+++ b/cli_code/Modules/Help.psm1
@@ -4,7 +4,7 @@ function Write-Line {
 }
 
 function Show-Help {
-    Write-Host "`nBenutze das CLI, indem du 'ct <befehl>' eingibst und mit Enter bestätigst.`nWähle einen der folgenden Befehle:`n" -ForegroundColor Yellow
+    Write-Host "`nListe der Befehle" -ForegroundColor Yellow
 
     $allowedCommands = Get-AllowedCommands
     $groups = $allowedCommands | Group-Object DirectoryName | Sort-Object Name
@@ -18,11 +18,11 @@ function Show-Help {
         $folderName = Split-Path $relativePath -Leaf
 
         if ($folderName -match "Commands") {
-            Write-Host "Allgemein" -ForegroundColor Yellow
+            Write-Host ("{0,-14} {1}" -f "Allgemein", "Verwendung: 'ct <befehl>'") -ForegroundColor Yellow
         } else {
-            Write-Host "$folderName" -ForegroundColor Yellow
+            Write-Host ("{0,-14} {1}" -f $folderName , "Verwendung: 'ct $folderName <befehl>'") -ForegroundColor Yellow
         }
-        Write-Host ("-" * 10) -ForegroundColor Yellow
+        Write-Host ("")
 
         $helpItems = foreach ($cmd in $group.Group | Sort-Object Name) {
             $name = $cmd.BaseName

--- a/cli_code/Modules/Help.psm1
+++ b/cli_code/Modules/Help.psm1
@@ -1,28 +1,21 @@
-function Write-Line {
-    $width = $Host.UI.RawUI.WindowSize.Width
-    Write-Host ("_" * $width) -ForegroundColor Yellow
-}
-
 function Show-Help {
-    Write-Host "`nListe der Befehle" -ForegroundColor Yellow
+    Out-Message "`nListe der Befehle"
 
     $allowedCommands = Get-AllowedCommands
     $groups = $allowedCommands | Group-Object DirectoryName | Sort-Object Name
 
     foreach ($group in $groups) {
-        Write-Line
-        Write-Host ""
+        Out-Line
         
         $relativePath = $group.Name -replace [regex]::Escape($PSScriptRoot), ''
         $relativePath = $relativePath.TrimStart('\','/')
         $folderName = Split-Path $relativePath -Leaf
 
         if ($folderName -match "Commands") {
-            Write-Host ("{0,-14} {1}" -f "Allgemein", "Verwendung: 'ct <befehl>'") -ForegroundColor Yellow
+            Out-Message ("{0,-14} {1}" -f "Allgemein", "Verwendung: 'ct <befehl>'")
         } else {
-            Write-Host ("{0,-14} {1}" -f $folderName , "Verwendung: 'ct $folderName <befehl>'") -ForegroundColor Yellow
+            Out-Message ("{0,-14} {1}" -f $folderName , "Verwendung: 'ct $folderName <befehl>'")
         }
-        Write-Host ("")
 
         $helpItems = foreach ($cmd in $group.Group | Sort-Object Name) {
             $name = $cmd.BaseName
@@ -45,12 +38,12 @@ function Show-Help {
         }
 
         foreach ($item in $helpItems) {
-            Write-Host ("- {0,-12} {1}" -f $item.Name, $item.FirstLine) -ForegroundColor Yellow
+            Out-Message ("- {0,-12} {1}" -f $item.Name, $item.FirstLine) 
 
             foreach ($line in $item.ExtraLines) {
-                Write-Host ("  {0,-12} {1}" -f "", $line) -ForegroundColor Yellow
+                Out-Message ("  {0,-12} {1}" -f "", $line)
             }
         }
-        Write-Host ""
     }
+    Write-Host ""
 }

--- a/cli_code/Modules/Init.psm1
+++ b/cli_code/Modules/Init.psm1
@@ -87,7 +87,7 @@ function Set-CliEnv {
     $envVars["CT_API_URL"] = Set-ApiUrl
     $envVars["CT_API_TOKEN"] = Set-ApiToken -ApiUrl $envVars["CT_API_URL"]
     $envVars["OUT_DIR"] = Set-OutDir
-    Update-DotEnv -EnvPath $EnvPath -KeyValuePairs $envVars
+    Update-DotEnv -KeyValuePairs $envVars
     Out-Message "Danke für deine Angaben! Das CLI ist jetzt fertig konfiguriert."
 }
 

--- a/cli_code/Modules/Init.psm1
+++ b/cli_code/Modules/Init.psm1
@@ -75,9 +75,6 @@ Für die Ersteinrichtung brauchst du dein Churchtools-Login-Token. Um es zu find
 "@
 
 function Set-CliEnv {
-    param(
-        [string]$EnvPath
-    )
     Out-Line
     Out-Message  "Willkommen zum Churchtools-CLI!"
     Out-Line

--- a/cli_code/Modules/Print.psm1
+++ b/cli_code/Modules/Print.psm1
@@ -1,0 +1,48 @@
+function Out-Message {
+    param (
+        [string]$Message,
+        [ValidateSet('info', 'warning', 'error', 'debug')]
+        [string]$Type = 'info'
+    )
+
+    switch ($Type) {
+        'warning' {
+            Write-Host $Message -ForegroundColor Yellow
+        }
+        'info' {
+            Write-Host $Message -ForegroundColor Green
+        }
+        'error' {
+            Write-Host $Message -ForegroundColor Red
+        }
+        'debug' {
+            Write-Host $Message -ForegroundColor White
+        }
+    }
+}
+
+function Out-Line {
+        param (
+        [ValidateSet('info', 'warning', 'error', 'debug')]
+        [string]$Type = 'info'
+    )
+    Write-Host ""
+
+    $width = $Host.UI.RawUI.WindowSize.Width
+    $Message = ("_" * $width)
+    switch ($Type) {
+        'warning' {
+            Write-Host $Message -ForegroundColor Yellow
+        }
+        'info' {
+            Write-Host $Message -ForegroundColor Green
+        }
+        'error' {
+            Write-Host $Message -ForegroundColor Red
+        }
+        'debug' {
+            Write-Host $Message -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}

--- a/cli_code/ct.ps1
+++ b/cli_code/ct.ps1
@@ -12,7 +12,7 @@ $initFile = Join-Path $PSScriptRoot "init"
 $envPath = Join-Path $PSScriptRoot ".env"
 
 function Use-MentionHelp {
-    Write-Host "Mit 'ct hilfe' kannst du eine Liste aller Befehle anzeigen lassen."  -ForegroundColor Blue
+    Out-Message "Mit 'ct hilfe' kannst du eine Liste aller Befehle anzeigen lassen."
 }
 
 try {
@@ -23,7 +23,7 @@ try {
     }
 
     if (-not $Command) {
-        Write-Host "Bitte Befehl eingeben und mit der Eingabetaste bestätigen." -ForegroundColor Blue
+        Out-Message "Bitte Befehl eingeben und mit der Eingabetaste bestätigen."
         Use-MentionHelp
         exit 1
     }
@@ -35,15 +35,15 @@ try {
     }
 
     if ($args.Flags.debug) {
-        Write-Host "Subcommands: $($args.Subcommands -join ', ')"
-        Write-Host "Arguments: $($args.Arguments | Out-String)"
-        Write-Host "Flags: $($args.Flags | Out-String)"
+        Out-Message "Subcommands: $($args.Subcommands -join ', ')" debug
+        Out-Message "Arguments: $($args.Arguments | Out-String)" debug
+        Out-Message "Flags: $($args.Flags | Out-String)" debug
     }
     
     $commandsDir = Join-Path $PSScriptRoot "Commands"
     $commandPath = Get-CommandPath -CommandsDir $commandsDir -Command $Command -SubCommands $args.Subcommands
     if (-not $commandPath) {
-        Write-Host "'$Command $AdditionalArgs' ist kein gültiger Befehl." -ForegroundColor Blue
+        Out-Message "'$Command $AdditionalArgs' ist kein gültiger Befehl."
         Use-MentionHelp
         exit 1
     }
@@ -52,13 +52,13 @@ try {
     $ct = [ChurchTools]::new($CT_API_URL, $CT_API_TOKEN)
 
     if ($allowedCommands.FullName -notcontains $commandPath) {
-        Write-Host "Du bist nicht berechtigt, diesen Befehl auszuführen." -ForegroundColor Red
+        Out-Message "Du bist nicht berechtigt, diesen Befehl auszuführen." -Type error
         throw "User $($ct.User.email) is not allowed to run command '$Command'."
     }
     . $commandPath @($AdditionalArgs)
 
     exit 0
 } catch {
-    Write-Host $_ -ForegroundColor Red
+    Out-Message $_ error
     $log.Write("Error in ct.ps1 $($_.Exception.Message)")
 }

--- a/cli_code/ct.ps1
+++ b/cli_code/ct.ps1
@@ -3,18 +3,12 @@ param (
     [string[]]$Args
 )
 
-$InstallPath = "$env:USERPROFILE\.ct"
-if (-not (Test-Path $InstallPath)) {
-    Write-Host "Installation wurde nicht gefunden."
-    exit 1
-}
+Set-Location -Path $PSScriptRoot
 
-Set-Location -Path $InstallPath
+. "$PSScriptRoot/preflight/run.ps1"
 
-. "$InstallPath/preflight/run.ps1"
-
-$initFile = Join-Path $InstallPath "init"
-$envPath = Join-Path $InstallPath ".env"
+$initFile = Join-Path $PSScriptRoot "init"
+$envPath = Join-Path $PSScriptRoot ".env"
 
 try {
     if (Test-Path $initFile) {
@@ -23,7 +17,7 @@ try {
         Get-DotEnv -Path $envPath
     }
 
-    $commandsDir = Join-Path $InstallPath "Commands"
+    $commandsDir = Join-Path $PSScriptRoot "Commands"
 
     if (-not $Command) {
         Write-Host "Kein Befehl angegeben. Benutzung:`nct <Befehl>`nDann mit der Eingabetaste bestätigen."

--- a/cli_code/ct.ps1
+++ b/cli_code/ct.ps1
@@ -9,7 +9,6 @@ Set-Location -Path $PSScriptRoot
 . "$PSScriptRoot/preflight/run.ps1"
 
 $initFile = Join-Path $PSScriptRoot "init"
-$envPath = Join-Path $PSScriptRoot ".env"
 
 function Use-MentionHelp {
     Out-Message "Mit 'ct hilfe' kannst du eine Liste aller Befehle anzeigen lassen."
@@ -19,7 +18,7 @@ try {
     if (Test-Path $initFile) {
         Set-CliEnv -EnvPath $envPath
         Remove-Item $initFile -ErrorAction SilentlyContinue
-        Get-DotEnv -Path $envPath
+        Get-DotEnv
     }
 
     if (-not $Command) {

--- a/cli_code/ct.ps1
+++ b/cli_code/ct.ps1
@@ -12,7 +12,7 @@ $initFile = Join-Path $PSScriptRoot "init"
 $envPath = Join-Path $PSScriptRoot ".env"
 
 function Use-MentionHelp {
-    Write-Host "Mit 'ct hilfe' kannst du verfügbare Befehle anzeigen lassen."  -ForegroundColor Blue
+    Write-Host "Mit 'ct hilfe' kannst du eine Liste aller Befehle anzeigen lassen."  -ForegroundColor Blue
 }
 
 try {

--- a/cli_code/ct.ps1
+++ b/cli_code/ct.ps1
@@ -8,19 +8,11 @@ Set-Location -Path $PSScriptRoot
 
 . "$PSScriptRoot/preflight/run.ps1"
 
-$initFile = Join-Path $PSScriptRoot "init"
-
 function Use-MentionHelp {
     Out-Message "Mit 'ct hilfe' kannst du eine Liste aller Befehle anzeigen lassen."
 }
 
 try {
-    if (Test-Path $initFile) {
-        Set-CliEnv -EnvPath $envPath
-        Remove-Item $initFile -ErrorAction SilentlyContinue
-        Get-DotEnv
-    }
-
     if (-not $Command) {
         Out-Message "Bitte Befehl eingeben und mit der Eingabetaste bestätigen."
         Use-MentionHelp

--- a/cli_code/preflight/installRequirements.ps1
+++ b/cli_code/preflight/installRequirements.ps1
@@ -9,7 +9,7 @@ foreach ($mod in $requirements.RequiredModules) {
     $installed = Get-Module -ListAvailable -Name $name | Where-Object { $_.Version -ge [Version]$minVersion }
 
     if (-not $installed) {
-        Out-Message "Installiere Modul $name (Min.-Version: $minVersion)..."
+        Out-Message "Installiere Modul $name ($($mod.Description))..."
         Install-Module -Name $name -MinimumVersion $minVersion -Force -Scope CurrentUser
     }
 }

--- a/cli_code/preflight/installRequirements.ps1
+++ b/cli_code/preflight/installRequirements.ps1
@@ -9,7 +9,7 @@ foreach ($mod in $requirements.RequiredModules) {
     $installed = Get-Module -ListAvailable -Name $name | Where-Object { $_.Version -ge [Version]$minVersion }
 
     if (-not $installed) {
-        Write-Host "Installiere Modul $name (Min.-Version: $minVersion)..."
+        Out-Message "Installiere Modul $name (Min.-Version: $minVersion)..."
         Install-Module -Name $name -MinimumVersion $minVersion -Force -Scope CurrentUser
     }
 }

--- a/cli_code/preflight/run.ps1
+++ b/cli_code/preflight/run.ps1
@@ -1,8 +1,7 @@
 . "$PSScriptRoot/loadClassesAndModules.ps1"
 . "$PSScriptRoot/installRequirements.ps1"
 
-$envPath = Join-Path $PWD ".env"
-Get-DotEnv -Path $envPath
+Get-DotEnv
 
 function Set-Encoding {
     [Console]::OutputEncoding = [Text.UTF8Encoding]::new()

--- a/cli_code/preflight/run.ps1
+++ b/cli_code/preflight/run.ps1
@@ -15,7 +15,14 @@ function Test-PSVersion {
     }
 }
 
+$initFile = Join-Path $PWD "init"
+
 try {
+    if (Test-Path $initFile) {
+        Set-CliEnv
+        Remove-Item $initFile -ErrorAction SilentlyContinue
+        Get-DotEnv
+    }
     Set-Encoding
     Test-PSVersion
 } catch {

--- a/cli_code/requirements.psd1
+++ b/cli_code/requirements.psd1
@@ -3,6 +3,7 @@
         @{
             Name = "BurntToast"
             MinimumVersion = "0.8.5"
+            Description = "Anzeigen von Desktop-Nachrichten"
         }
     )
 }


### PR DESCRIPTION
The CLI now acepts multi-word commands following the directory structure in "commands". Moreover it is able to parse key-value pairs (key=value) or flags (--myflags) as bools from the cmd line input.

Also updated/refactored print statements, using functions to set color throughout CLI.