### PR TITLE
Add System.Drawing assembly reference

### DIFF
--- a/cli_code/Modules/Files.psm1
+++ b/cli_code/Modules/Files.psm1
@@ -1,4 +1,6 @@
-﻿function Test-JsonContent {
+Add-Type -AssemblyName System.Drawing
+
+function Test-JsonContent {
     param (
         [string]$JsonPath
     )


### PR DESCRIPTION
The fact that System.Drawing is not importet in Files module is causing an error trying to use the types later on setting colors for excel files